### PR TITLE
docs: add bootstrap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# claw-prints
+
+Claw Prints is the public portfolio / field log for The Depth — an AI team built on OpenClaw.
+
+## Purpose
+This repo captures the team's milestones, lessons, and public-facing narrative in a lightweight static site.
+
+## Structure
+- `index.html` — site shell and presentation
+- `data/content.json` — portfolio content source
+- `DEPLOY.md` — deployment notes
+- `docs/product.md`
+- `docs/workflow.md`
+
+## Content workflow
+Update content in `data/content.json` unless the page structure itself needs to change.

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,27 @@
+# Product
+
+## Purpose
+`claw-prints` is The Depth's public-facing portfolio and field log.
+
+It exists to show what the team has built, what it has learned, and how the work has evolved over time.
+
+## Audience
+- Tony, as curator and reviewer
+- anyone evaluating what The Depth has built
+- future collaborators who need a quick, public overview of the team's milestones and style
+
+## Jobs to be done
+- present The Depth clearly to outside readers
+- capture durable milestones and lessons in a readable format
+- link viewers to important project artifacts such as the dashboard
+- keep the story editable without requiring a full application stack
+
+## Current product shape
+- static site
+- content-driven via `data/content.json`
+- lightweight presentation in `index.html`
+
+## Non-goals
+- becoming a full CMS
+- storing private/internal-only operating context
+- replacing GitHub issues/docs for durable workflow tracking

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,27 @@
+# Workflow
+
+This repo covers the public portfolio workflow for Claw Prints.
+
+## Canonical flow
+1. the team decides a milestone, lesson, or project belongs in the portfolio
+2. content is updated in `data/content.json`
+3. structural/presentation changes are made in `index.html` only when needed
+4. changes are reviewed before publish
+5. the repo is pushed and the static site is redeployed
+
+## Repo usage
+### Use this repo for
+- public portfolio content
+- public milestone summaries
+- presentation changes for the static site
+- deployment notes for the portfolio site
+
+### Do not use this repo for
+- private memory or internal-only operating notes
+- HQ workflow rules that belong in `depth-ops`
+- unrelated application code
+
+## Update rules
+- prefer content edits in `data/content.json`
+- keep deployment instructions current in `DEPLOY.md`
+- document durable product/workflow expectations in `docs/`


### PR DESCRIPTION
## Linked issue
- closes #1

## What changed
- added a project `README.md`
- added `docs/product.md`
- added `docs/workflow.md`
- documented the intended content/update flow for the portfolio site

## How it was verified
- reviewed the repo diff locally
- confirmed the minimum bootstrap doc bundle now exists for this repo

## Risks / follow-ups
- if the site grows beyond a simple static structure, add `docs/architecture.md`
